### PR TITLE
Allow setting allowpublic property for UAA clients

### DIFF
--- a/acceptance-tests.sh
+++ b/acceptance-tests.sh
@@ -93,7 +93,7 @@ if [ "${binding_guid_b}" != "${client_id_b}" ]; then
   echo "Incorrect client id ${client_id_b}; expected ${binding_guid_b}"
 fi
 
-# User exists in UAA
+# Client exists in UAA
 uaac client get "${binding_guid}"
 uaac client get "${binding_guid_b}"
 
@@ -102,14 +102,14 @@ cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}"
 cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_B}"
 cf delete-service -f "${SERVICE_INSTANCE_NAME}"
 
-# User does not exist in UAA
+# Client does not exist in UAA
 if uaac client get "${binding_guid}"; then
-  echo "Unexpectedly found user ${binding_guid} in UAA"
+  echo "Unexpectedly found client ${binding_guid} in UAA"
   exit 1
 fi
 
 if uaac client get "${binding_guid_b}"; then
-  echo "Unexpectedly found user ${binding_guid_b} in UAA"
+  echo "Unexpectedly found client ${binding_guid_b} in UAA"
   exit 1
 fi
 

--- a/acceptance-tests.sh
+++ b/acceptance-tests.sh
@@ -78,12 +78,20 @@ fi
 cf create-service "${CLIENT_SERVICE_NAME}" "${CLIENT_PLAN_NAME}" "${SERVICE_INSTANCE_NAME}"
 cf create-service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}" -c '{"redirect_uri": ["https://cloud.gov"]}'
 cf create-service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_B}" -c '{"redirect_uri": ["https://cloud.gov"]}'
+
+SERVICE_KEY_NAME_ALLOWPUBLIC="${SERVICE_KEY_NAME_ALLOWPUBLIC:-creds_allowpublic}"
+cf create-service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_ALLOWPUBLIC}" \
+  -c '{"redirect_uri": ["https://cloud.gov"], "allowpublic": true}'
+
 key=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}" | tail -n +2)
 key_b=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_B}" | tail -n +2)
+allowpublic_key=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_ALLOWPUBLIC}" | tail -n +2)
 client_id=$(echo "${key}" | jq -r ".client_id")
 client_id_b=$(echo "${key_b}" | jq -r ".client_id")
+client_id_allowpublic=$(echo "${allowpublic_key}" | jq -r ".client_id")
 binding_guid=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}" --guid)
 binding_guid_b=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_B}" --guid)
+binding_guid_allowpublic=$(cf service-key "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_ALLOWPUBLIC}" --guid)
 
 if [ "${binding_guid}" != "${client_id}" ]; then
   echo "Incorrect client id ${client_id}; expected ${binding_guid}"
@@ -93,9 +101,16 @@ if [ "${binding_guid_b}" != "${client_id_b}" ]; then
   echo "Incorrect client id ${client_id_b}; expected ${binding_guid_b}"
 fi
 
+if [ "${binding_guid_allowpublic}" != "${client_id_allowpublic}" ]; then
+  echo "Incorrect client id ${client_id_allowpublic}; expected ${binding_guid_allowpublic}"
+fi
+
 # Client exists in UAA
 uaac client get "${binding_guid}"
 uaac client get "${binding_guid_b}"
+
+# Check that allowpublic is set on client
+uaac client get "${binding_guid_allowpublic}" | grep "allowpublic"
 
 # Delete service instance
 cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}"
@@ -113,10 +128,16 @@ if uaac client get "${binding_guid_b}"; then
   exit 1
 fi
 
+if uaac client get "${binding_guid_allowpublic}"; then
+  echo "Unexpectedly found client ${binding_guid_allowpublic} in UAA"
+  exit 1
+fi
+
 # Ensure service instance is deleted
 teardown() {
   cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME}" || true
   cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_B}" || true
+  cf delete-service-key -f "${SERVICE_INSTANCE_NAME}" "${SERVICE_KEY_NAME_ALLOWPUBLIC}" || true
   cf delete-service -f "${SERVICE_INSTANCE_NAME}" || true
 }
 trap teardown EXIT

--- a/acceptance-tests.yml
+++ b/acceptance-tests.yml
@@ -1,9 +1,14 @@
 ---
 platform: linux
+
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/concourse-task
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    tag: ((harden-concourse-task-tag))
 
 inputs:
 - name: broker-src

--- a/broker.go
+++ b/broker.go
@@ -258,7 +258,7 @@ func (b *DeployerAccountBroker) provisionClient(
 		return Client{}, fmt.Errorf("Scope(s) not permitted: %s", strings.Join(forbiddenScopes, ", "))
 	}
 
-	return b.uaaClient.CreateClient(Client{
+	client := Client{
 		ID:                   clientID,
 		AuthorizedGrantTypes: []string{"authorization_code", "refresh_token"},
 		Scope:                scopes,
@@ -266,8 +266,13 @@ func (b *DeployerAccountBroker) provisionClient(
 		ClientSecret:         clientSecret,
 		AccessTokenValidity:  b.config.AccessTokenValidity,
 		RefreshTokenValidity: b.config.RefreshTokenValidity,
-		AllowPublic:          *opts.AllowPublic,
-	})
+	}
+
+	if opts.AllowPublic != nil {
+		client.AllowPublic = *opts.AllowPublic
+	}
+
+	return b.uaaClient.CreateClient(client)
 }
 
 func (b *DeployerAccountBroker) provisionUser(userID, password string) (User, error) {

--- a/broker.go
+++ b/broker.go
@@ -19,7 +19,7 @@ import (
 type BindOptions struct {
 	RedirectURI []string `json:"redirect_uri"`
 	Scopes      []string `json:"scopes"`
-	AllowPublic *bool    `json:"allow_public"`
+	AllowPublic *bool    `json:"allowpublic"`
 }
 
 var (

--- a/broker_test.go
+++ b/broker_test.go
@@ -123,7 +123,7 @@ var _ = Describe("broker", func() {
 					},
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(`Must pass JSON configuration with field "redirect_uri"`))
+				Expect(err.Error()).To(Equal(`must pass JSON configuration with field "redirect_uri"`))
 			})
 
 			It("errors if params incomplete", func() {
@@ -148,7 +148,7 @@ var _ = Describe("broker", func() {
 					},
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(`Must pass field "redirect_uri"`))
+				Expect(err.Error()).To(Equal(`must pass field "redirect_uri"`))
 			})
 
 			It("accepts allowed scopes", func() {
@@ -190,6 +190,33 @@ var _ = Describe("broker", func() {
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Scope(s) not permitted: cloud_controller.write"))
+			})
+
+			It("uses specified allowpublic value", func() {
+				uaaClient.On("CreateClient", Client{
+					ID:                   "binding-guid",
+					AuthorizedGrantTypes: []string{"authorization_code", "refresh_token"},
+					Scope:                []string{"openid"},
+					RedirectURI:          []string{"https://cloud.gov"},
+					ClientSecret:         "password",
+					AccessTokenValidity:  600,
+					RefreshTokenValidity: 86400,
+					AllowPublic:          true,
+				}).Return(Client{ID: "client-guid"}, nil)
+
+				_, err := broker.Bind(
+					context.Background(),
+					"instance-guid",
+					"binding-guid",
+					brokerapi.BindDetails{
+						AppGUID:       "app-guid",
+						ServiceID:     clientAccountGUID,
+						RawParameters: []byte(`{"redirect_uri": ["https://cloud.gov"], "scopes": ["openid"], "allow_public": true}`),
+					},
+				)
+				Expect(err).NotTo(HaveOccurred())
+				cfClient.AssertExpectations(GinkgoT())
+				uaaClient.AssertExpectations(GinkgoT())
 			})
 		})
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -115,7 +115,7 @@ var _ = Describe("broker", func() {
 
 			It("returns options with allowpublic", func() {
 				options, err := parseBindOptions(brokerapi.BindDetails{
-					RawParameters: []byte(`{"redirect_uri":["example.com"], "allow_public": true}`),
+					RawParameters: []byte(`{"redirect_uri":["example.com"], "allowpublic": true}`),
 				})
 				Expect(err).NotTo(HaveOccurred())
 				allowPublicTrue := true
@@ -262,7 +262,7 @@ var _ = Describe("broker", func() {
 					brokerapi.BindDetails{
 						AppGUID:       "app-guid",
 						ServiceID:     clientAccountGUID,
-						RawParameters: []byte(`{"redirect_uri": ["https://cloud.gov"], "scopes": ["openid"], "allow_public": true}`),
+						RawParameters: []byte(`{"redirect_uri": ["https://cloud.gov"], "scopes": ["openid"], "allowpublic": true}`),
 					},
 				)
 				Expect(err).NotTo(HaveOccurred())

--- a/broker_test.go
+++ b/broker_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"reflect"
+	"testing"
 
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -293,3 +295,67 @@ var _ = Describe("broker", func() {
 		})
 	})
 })
+
+func TestParseBindOptions(t *testing.T) {
+	allowpublicTrue := true
+	testCases := map[string]struct {
+		bindDetails     brokerapi.BindDetails
+		expectedOptions BindOptions
+		expectErr       bool
+	}{
+		"no input": {
+			bindDetails: brokerapi.BindDetails{
+				RawParameters: []byte(``),
+			},
+			expectedOptions: BindOptions{},
+			expectErr:       true,
+		},
+		"no redirect uri specified": {
+			bindDetails: brokerapi.BindDetails{
+				RawParameters: []byte(`{"redirect_uri":[]}`),
+			},
+			expectedOptions: BindOptions{
+				RedirectURI: []string{},
+			},
+			expectErr: true,
+		},
+		"specify redirect URI": {
+			bindDetails: brokerapi.BindDetails{
+				RawParameters: []byte(`{"redirect_uri":["example.com"]}`),
+			},
+			expectedOptions: BindOptions{
+				RedirectURI: []string{"example.com"},
+			},
+		},
+		"specify scopes": {
+			bindDetails: brokerapi.BindDetails{
+				RawParameters: []byte(`{"redirect_uri":["example.com"], "scopes":["scope1"]}`),
+			},
+			expectedOptions: BindOptions{
+				RedirectURI: []string{"example.com"},
+				Scopes:      []string{"scope1"},
+			},
+		},
+		"specify allowpublic": {
+			bindDetails: brokerapi.BindDetails{
+				RawParameters: []byte(`{"redirect_uri":["example.com"], "allow_public": true}`),
+			},
+			expectedOptions: BindOptions{
+				RedirectURI: []string{"example.com"},
+				AllowPublic: &allowpublicTrue,
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			options, err := parseBindOptions(test.bindDetails)
+			if err != nil && !test.expectErr {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !reflect.DeepEqual(test.expectedOptions, options) {
+				t.Errorf("expected: %#v, got: %#v", test.expectedOptions, options)
+			}
+		})
+	}
+}

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestMain(t *testing.T) {

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -2,10 +2,29 @@
 jobs:
 - name: test-broker
   plan:
-  - get: broker-src
+  - get: pull-request
+    version: every
     trigger: true
+  - get: broker-src
+  - put: pull-request
+    params:
+      path: pull-request
+      status: pending
+      context: run-tests
   - task: run-tests
     file: broker-src/run-tests.yml
+    on_success:
+      put: pull-request
+      params:
+        path: pull-request
+        status: success
+        context: run-tests
+    on_failure:
+      put: pull-request
+      params:
+        path: pull-request
+        status: failure
+        context: run-tests
 
 - name: push-broker-staging
   serial_groups: [staging]
@@ -175,370 +194,6 @@ jobs:
       USER_PLAN_NAME: space-deployer
       SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
 
-- name: push-broker-westb
-  serial_groups: [westb]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: pipeline-tasks
-      passed: [push-broker-staging]
-  - put: broker-deploy-westb
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-westb))
-        UAA_CLIENT_ID: ((uaa-client-id-westb))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-westb))
-        UAA_ZONE: ((uaa-zone-westb))
-        CF_ADDRESS: ((cf-api-url-westb))
-        BROKER_USERNAME: ((broker-username-westb))
-        BROKER_PASSWORD: ((broker-password-westb))
-        EMAIL_ADDRESS: ((email-address-westb))
-  - task: update-broker-identity-provider
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-westb))
-      CF_USERNAME: ((cf-deploy-username-westb))
-      CF_PASSWORD: ((cf-deploy-password-westb))
-      CF_ORGANIZATION: ((cf-organization-westb))
-      CF_SPACE: ((cf-space-westb))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-westb))
-      AUTH_PASS: ((broker-password-westb))
-      SERVICES: cloud-gov-identity-provider
-  - task: update-broker-service-account
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-westb))
-      CF_USERNAME: ((cf-deploy-username-westb))
-      CF_PASSWORD: ((cf-deploy-password-westb))
-      CF_ORGANIZATION: ((cf-organization-westb))
-      CF_SPACE: ((cf-space-westb))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-westb))
-      AUTH_PASS: ((broker-password-westb))
-      SERVICES: cloud-gov-service-account
-      SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-westb))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-westb))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-westb
-  serial_groups: [westb]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-westb]
-    trigger: true
-  - task: acceptance-tests-westb
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-westb))
-      CF_USERNAME: ((cf-deploy-username-test-westb))
-      CF_PASSWORD: ((cf-deploy-password-test-westb))
-      CF_ORGANIZATION: ((cf-organization-test-westb))
-      CF_SPACE: ((cf-space-test-westb))
-      UAA_API_URL: ((uaa-address-westb))
-      UAA_CLIENT_ID: ((uaa-client-id-test-westb))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-westb))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
-
-- name: push-broker-easta
-  serial_groups: [easta]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: pipeline-tasks
-      passed: [push-broker-staging]
-  - put: broker-deploy-easta
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-easta))
-        UAA_CLIENT_ID: ((uaa-client-id-easta))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-easta))
-        UAA_ZONE: ((uaa-zone-easta))
-        CF_ADDRESS: ((cf-api-url-easta))
-        BROKER_USERNAME: ((broker-username-easta))
-        BROKER_PASSWORD: ((broker-password-easta))
-        EMAIL_ADDRESS: ((email-address-easta))
-  - task: update-broker-identity-provider
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-easta))
-      CF_USERNAME: ((cf-deploy-username-easta))
-      CF_PASSWORD: ((cf-deploy-password-easta))
-      CF_ORGANIZATION: ((cf-organization-easta))
-      CF_SPACE: ((cf-space-easta))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-easta))
-      AUTH_PASS: ((broker-password-easta))
-      SERVICES: cloud-gov-identity-provider
-  - task: update-broker-service-account
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-easta))
-      CF_USERNAME: ((cf-deploy-username-easta))
-      CF_PASSWORD: ((cf-deploy-password-easta))
-      CF_ORGANIZATION: ((cf-organization-easta))
-      CF_SPACE: ((cf-space-easta))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-easta))
-      AUTH_PASS: ((broker-password-easta))
-      SERVICES: cloud-gov-service-account
-      SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-easta))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-easta))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-easta
-  serial_groups: [easta]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-easta]
-    trigger: true
-  - task: acceptance-tests-easta
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-easta))
-      CF_USERNAME: ((cf-deploy-username-test-easta))
-      CF_PASSWORD: ((cf-deploy-password-test-easta))
-      CF_ORGANIZATION: ((cf-organization-test-easta))
-      CF_SPACE: ((cf-space-test-easta))
-      UAA_API_URL: ((uaa-address-easta))
-      UAA_CLIENT_ID: ((uaa-client-id-test-easta))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-easta))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
-
-- name: push-broker-westc
-  serial_groups: [westc]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: pipeline-tasks
-      passed: [push-broker-staging]
-  - put: broker-deploy-westc
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-westc))
-        UAA_CLIENT_ID: ((uaa-client-id-westc))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-westc))
-        UAA_ZONE: ((uaa-zone-westc))
-        CF_ADDRESS: ((cf-api-url-westc))
-        BROKER_USERNAME: ((broker-username-westc))
-        BROKER_PASSWORD: ((broker-password-westc))
-        EMAIL_ADDRESS: ((email-address-westc))
-  - task: update-broker-identity-provider
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-westc))
-      CF_USERNAME: ((cf-deploy-username-westc))
-      CF_PASSWORD: ((cf-deploy-password-westc))
-      CF_ORGANIZATION: ((cf-organization-westc))
-      CF_SPACE: ((cf-space-westc))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-westc))
-      AUTH_PASS: ((broker-password-westc))
-      SERVICES: cloud-gov-identity-provider
-  - task: update-broker-service-account
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-westc))
-      CF_USERNAME: ((cf-deploy-username-westc))
-      CF_PASSWORD: ((cf-deploy-password-westc))
-      CF_ORGANIZATION: ((cf-organization-westc))
-      CF_SPACE: ((cf-space-westc))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-westc))
-      AUTH_PASS: ((broker-password-westc))
-      SERVICES: cloud-gov-service-account
-      SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-westc))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-westc))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-westc
-  serial_groups: [westc]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-westc]
-    trigger: true
-  - task: acceptance-tests-westc
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-westc))
-      CF_USERNAME: ((cf-deploy-username-test-westc))
-      CF_PASSWORD: ((cf-deploy-password-test-westc))
-      CF_ORGANIZATION: ((cf-organization-test-westc))
-      CF_SPACE: ((cf-space-test-westc))
-      UAA_API_URL: ((uaa-address-westc))
-      UAA_CLIENT_ID: ((uaa-client-id-test-westc))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-westc))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
-
-- name: push-broker-eastb
-  serial_groups: [eastb]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: pipeline-tasks
-      passed: [push-broker-staging]
-  - put: broker-deploy-eastb
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-eastb))
-        UAA_CLIENT_ID: ((uaa-client-id-eastb))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-eastb))
-        UAA_ZONE: ((uaa-zone-eastb))
-        CF_ADDRESS: ((cf-api-url-eastb))
-        BROKER_USERNAME: ((broker-username-eastb))
-        BROKER_PASSWORD: ((broker-password-eastb))
-        EMAIL_ADDRESS: ((email-address-eastb))
-  - task: update-broker-identity-provider
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-eastb))
-      CF_USERNAME: ((cf-deploy-username-eastb))
-      CF_PASSWORD: ((cf-deploy-password-eastb))
-      CF_ORGANIZATION: ((cf-organization-eastb))
-      CF_SPACE: ((cf-space-eastb))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-eastb))
-      AUTH_PASS: ((broker-password-eastb))
-      SERVICES: cloud-gov-identity-provider
-  - task: update-broker-service-account
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-eastb))
-      CF_USERNAME: ((cf-deploy-username-eastb))
-      CF_PASSWORD: ((cf-deploy-password-eastb))
-      CF_ORGANIZATION: ((cf-organization-eastb))
-      CF_SPACE: ((cf-space-eastb))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-eastb))
-      AUTH_PASS: ((broker-password-eastb))
-      SERVICES: cloud-gov-service-account
-      SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-eastb))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-eastb))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-eastb
-  serial_groups: [eastb]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-eastb]
-    trigger: true
-  - task: acceptance-tests-eastb
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-eastb))
-      CF_USERNAME: ((cf-deploy-username-test-eastb))
-      CF_PASSWORD: ((cf-deploy-password-test-eastb))
-      CF_ORGANIZATION: ((cf-organization-test-eastb))
-      CF_SPACE: ((cf-space-test-eastb))
-      UAA_API_URL: ((uaa-address-eastb))
-      UAA_CLIENT_ID: ((uaa-client-id-test-eastb))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-eastb))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
-
 resources:
 - name: broker-src
   type: git
@@ -571,49 +226,26 @@ resources:
     organization: ((cf-organization-production))
     space: ((cf-space-production))
 
-- name: broker-deploy-westb
-  type: cf
-  source:
-    api: ((cf-api-url-westb))
-    username: ((cf-deploy-username-westb))
-    password: ((cf-deploy-password-westb))
-    organization: ((cf-organization-westb))
-    space: ((cf-space-westb))
-
-- name: broker-deploy-easta
-  type: cf
-  source:
-    api: ((cf-api-url-easta))
-    username: ((cf-deploy-username-easta))
-    password: ((cf-deploy-password-easta))
-    organization: ((cf-organization-easta))
-    space: ((cf-space-easta))
-
-- name: broker-deploy-westc
-  type: cf
-  source:
-    api: ((cf-api-url-westc))
-    username: ((cf-deploy-username-westc))
-    password: ((cf-deploy-password-westc))
-    organization: ((cf-organization-westc))
-    space: ((cf-space-westc))
-
-- name: broker-deploy-eastb
-  type: cf
-  source:
-    api: ((cf-api-url-eastb))
-    username: ((cf-deploy-username-eastb))
-    password: ((cf-deploy-password-eastb))
-    organization: ((cf-organization-eastb))
-    space: ((cf-space-eastb))
-
 - name: slack
   type: slack-notification
   source:
     url: ((slack-webhook-url))
+
+- name: pull-request
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: cloud-gov/uaa-credentials-broker
+    access_token: ((ci-bot-status-access-token))
+    disable_forks: true
 
 resource_types:
 - name: slack-notification
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
       status: pending
       context: run-tests
   - task: run-tests
-    file: broker-src/run-tests.yml
+    file: pull-request/run-tests.yml
     on_success:
       put: pull-request
       params:

--- a/run-tests.yml
+++ b/run-tests.yml
@@ -11,7 +11,7 @@ image_resource:
     tag: ((harden-concourse-task-tag))
 
 inputs:
-- name: broker-src
+- name: pull-request
   path: uaa-credentials-broker
 
 run:

--- a/run-tests.yml
+++ b/run-tests.yml
@@ -2,10 +2,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: golang
-    tag: "1.19"
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    tag: ((harden-concourse-task-tag))
 
 inputs:
 - name: broker-src

--- a/uaa.go
+++ b/uaa.go
@@ -36,7 +36,7 @@ type Client struct {
 	Active               bool     `json:"active,omitempty"`
 	AccessTokenValidity  int      `json:"access_token_validity,omitempty"`
 	RefreshTokenValidity int      `json:"refresh_token_validity,omitempty"`
-	AllowPublic          bool     `json:"allow_public,omitempty"`
+	AllowPublic          bool     `json:"allowpublic,omitempty"`
 }
 
 type Email struct {

--- a/uaa.go
+++ b/uaa.go
@@ -36,6 +36,7 @@ type Client struct {
 	Active               bool     `json:"active,omitempty"`
 	AccessTokenValidity  int      `json:"access_token_validity,omitempty"`
 	RefreshTokenValidity int      `json:"refresh_token_validity,omitempty"`
+	AllowPublic          bool     `json:"allow_public,omitempty"`
 }
 
 type Email struct {


### PR DESCRIPTION
Related to #62 

## Changes proposed in this pull request:

- Update broker to allow specifying `allowpublic` option when binding a new UAA client to enable [PKCE authentication flows](https://www.oauth.com/oauth2-servers/pkce/)
- Add unit tests for `allowpublic` option
- Add acceptance test for new `allowpublic` option

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

The security considerations of this change are discussed at length in #62 . 
