### PR TITLE
Update UAA client deletion logic on unbind

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cloud Foundry UAA Credentials Broker
 This service broker allows Cloud Foundry users to provision and deprovision UAA users and clients:
 
 * UAA users managed by the broker are scoped to a given organization and space and can be used to push applications when password authentication is needed--such as when deploying from a continuous integration service. Live example: [the cloud.gov service account service](https://cloud.gov/docs/services/cloud-gov-service-account/).
-* UAA clients can be used to leverage UAA authentication in tenant applications. Live example: [leveraging cloud.gov authentication](https://cloud.gov/docs/apps/leveraging-authentication/) using the [cloud.gov identity provider service](https://cloud.gov/docs/services/cloud-gov-identity-provider/).
+* UAA clients can be used to leverage UAA authentication in tenant applications. Live example: [leveraging cloud.gov authentication](https://cloud.gov/docs/management/leveraging-authentication/) using the [cloud.gov identity provider service](https://cloud.gov/docs/services/cloud-gov-identity-provider/).
 
 ## Usage
 

--- a/broker.go
+++ b/broker.go
@@ -78,7 +78,11 @@ func (b *DeployerAccountBroker) Deprovision(
 	// Handle instances created before credential management was moved to bind and unbind
 	switch details.ServiceID {
 	case clientAccountGUID:
-		if err := b.uaaClient.DeleteClient(instanceID); err != nil && !strings.Contains(err.Error(), "404") {
+		if err := b.uaaClient.DeleteClient(instanceID); err != nil {
+			// allow 404 responses
+			if strings.Contains(err.Error(), "404") {
+				return brokerapi.DeprovisionServiceSpec{}, nil
+			}
 			return brokerapi.DeprovisionServiceSpec{}, err
 		}
 	case userAccountGUID:

--- a/broker_test.go
+++ b/broker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -27,8 +28,8 @@ func (c *FakeUAAClient) CreateClient(client Client) (Client, error) {
 }
 
 func (c *FakeUAAClient) DeleteClient(clientID string) error {
-	c.Called(clientID)
-	return nil
+	args := c.Called(clientID)
+	return args.Error(0)
 }
 
 func (c *FakeUAAClient) GetUser(userID string) (User, error) {
@@ -271,8 +272,8 @@ var _ = Describe("broker", func() {
 			})
 		})
 
-		Describe("deprovision", func() {
-			It("returns a deprovision service spec", func() {
+		Describe("unbind", func() {
+			It("does not return an error", func() {
 				uaaClient.On("DeleteClient", "binding-guid").Return(nil)
 
 				err := broker.Unbind(
@@ -286,6 +287,53 @@ var _ = Describe("broker", func() {
 				Expect(err).NotTo(HaveOccurred())
 				uaaClient.AssertExpectations(GinkgoT())
 			})
+		})
+
+		Describe("deprovision", func() {
+			It("does not return an error", func() {
+				uaaClient.On("DeleteClient", "binding-guid").Return(nil)
+
+				err := broker.Unbind(
+					context.Background(),
+					"instance-guid",
+					"binding-guid",
+					brokerapi.UnbindDetails{
+						ServiceID: clientAccountGUID,
+					},
+				)
+				Expect(err).NotTo(HaveOccurred())
+				uaaClient.AssertExpectations(GinkgoT())
+			})
+		})
+
+		It("does not return an error for a 404 response on deletion", func() {
+			uaaClient.On("DeleteClient", "instance-guid2").Return(fmt.Errorf("Expected status 200; got: %d", 404))
+
+			_, err := broker.Deprovision(
+				context.Background(),
+				"instance-guid2",
+				brokerapi.DeprovisionDetails{
+					ServiceID: clientAccountGUID,
+				},
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			uaaClient.AssertExpectations(GinkgoT())
+		})
+
+		It("does return an error for a response other than 200/404 on deletion", func() {
+			uaaClient.On("DeleteClient", "instance-guid3").Return(fmt.Errorf("Expected status 200; got: %d", 500))
+
+			_, err := broker.Deprovision(
+				context.Background(),
+				"instance-guid3",
+				brokerapi.DeprovisionDetails{
+					ServiceID: clientAccountGUID,
+				},
+				false,
+			)
+			Expect(err).To(HaveOccurred())
+			uaaClient.AssertExpectations(GinkgoT())
 		})
 	})
 


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR update broker delete logic to not fail on 404 responses for UAA client deletion. The current code logic for unbind was treating a 404 from UAA client deletion as an error, whereas the same logic for deprovision was **not treating** a 404 on UAA client deletion as an error.

The broker should ignore a 404 response when deleting the UAA client since it is possible for the broker to fail creating a UAA client but the cloud controller to save a record for that service binding. In that case, with the current unbind logic, it is impossible to delete the record for the failed UAA client because it'll continue return a 404 on deletion.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just refactoring delete/unbind logic for consistency
