### PR TITLE
update pipeline to use hardened images

### DIFF
--- a/acceptance-tests.yml
+++ b/acceptance-tests.yml
@@ -1,17 +1,8 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
-- name: broker-src
+  - name: broker-src
 
 run:
   path: broker-src/acceptance-tests.sh

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,290 +1,308 @@
 ---
 jobs:
-- name: test-broker
-  plan:
-  - get: pull-request
-    version: every
-    trigger: true
-  - get: broker-src
-  - put: pull-request
-    params:
-      path: pull-request
-      status: pending
-      context: run-tests
-  - task: run-tests
-    file: pull-request/run-tests.yml
-    on_success:
-      put: pull-request
-      params:
-        path: pull-request
-        status: success
-        context: run-tests
+  - name: test-broker
+    plan:
+      - get: pull-request
+        version: every
+        trigger: true
+      - get: broker-src
+      - get: general-task
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          context: run-tests
+      - task: run-tests
+        image: general-task
+        file: pull-request/run-tests.yml
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            context: run-tests
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            context: run-tests
+
+  - name: reconfigure
+    plan:
+      - get: broker-src
+        trigger: true
+      - set_pipeline: deploy-uaa-credentials-broker
+        file: broker-src/pipeline.yml
+
+  - name: push-broker-staging
+    serial_groups: [staging]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: broker-src
+            trigger: true
+            passed: [reconfigure]
+          - get: pipeline-tasks
+      - put: broker-deploy-staging
+        params:
+          path: broker-src
+          manifest: broker-src/manifest.yml
+          environment_variables:
+            UAA_ADDRESS: ((uaa-address-staging))
+            UAA_CLIENT_ID: ((uaa-client-id-staging))
+            UAA_CLIENT_SECRET: ((uaa-client-secret-staging))
+            UAA_ZONE: ((uaa-zone-staging))
+            CF_ADDRESS: ((cf-api-url-staging))
+            BROKER_USERNAME: ((broker-username-staging))
+            BROKER_PASSWORD: ((broker-password-staging))
+            EMAIL_ADDRESS: ((email-address-staging))
+      - task: update-broker
+        file: pipeline-tasks/register-service-broker.yml
+        params:
+          CF_API_URL: ((cf-api-url-staging))
+          CF_USERNAME: ((cf-deploy-username-staging))
+          CF_PASSWORD: ((cf-deploy-password-staging))
+          CF_ORGANIZATION: ((cf-organization-staging))
+          CF_SPACE: ((cf-space-staging))
+          BROKER_NAME: uaa-credentials-broker
+          AUTH_USER: ((broker-username-staging))
+          AUTH_PASS: ((broker-password-staging))
+          SERVICES: cloud-gov-service-account cloud-gov-identity-provider
     on_failure:
-      put: pull-request
+      put: slack
       params:
-        path: pull-request
-        status: failure
-        context: run-tests
+        text: |
+          :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-staging))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-failure-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-staging))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-success-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
-- name: reconfigure
-  plan:
-  - get: broker-src
-    trigger: true
-  - set_pipeline: deploy-uaa-credentials-broker
-    file: broker-src/pipeline.yml
+  - name: acceptance-tests-staging
+    serial_groups: [staging]
+    serial: true
+    plan:
+      - get: broker-src
+        passed: [push-broker-staging]
+        trigger: true
+      - get: general-task
+      - task: acceptance-tests-staging
+        image: general-task
+        file: broker-src/acceptance-tests.yml
+        params:
+          CF_API_URL: ((cf-api-url-staging))
+          CF_USERNAME: ((cf-deploy-username-test-staging))
+          CF_PASSWORD: ((cf-deploy-password-test-staging))
+          CF_ORGANIZATION: ((cf-organization-test-staging))
+          CF_SPACE: ((cf-space-test-staging))
+          UAA_API_URL: ((uaa-address-staging))
+          UAA_CLIENT_ID: ((uaa-client-id-test-staging))
+          UAA_CLIENT_SECRET: ((uaa-client-secret-test-staging))
+          CLIENT_SERVICE_NAME: cloud-gov-identity-provider
+          USER_SERVICE_NAME: cloud-gov-service-account
+          CLIENT_PLAN_NAME: oauth-client
+          USER_PLAN_NAME: space-deployer
+          SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
 
-- name: push-broker-staging
-  serial_groups: [staging]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      trigger: true
-      passed: [reconfigure]
-    - get: pipeline-tasks
-  - put: broker-deploy-staging
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-staging))
-        UAA_CLIENT_ID: ((uaa-client-id-staging))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-staging))
-        UAA_ZONE: ((uaa-zone-staging))
-        CF_ADDRESS: ((cf-api-url-staging))
-        BROKER_USERNAME: ((broker-username-staging))
-        BROKER_PASSWORD: ((broker-password-staging))
-        EMAIL_ADDRESS: ((email-address-staging))
-  - task: update-broker
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-staging))
-      CF_USERNAME: ((cf-deploy-username-staging))
-      CF_PASSWORD: ((cf-deploy-password-staging))
-      CF_ORGANIZATION: ((cf-organization-staging))
-      CF_SPACE: ((cf-space-staging))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-staging))
-      AUTH_PASS: ((broker-password-staging))
-      SERVICES: cloud-gov-service-account cloud-gov-identity-provider
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-staging))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-failure-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-staging))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-success-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
+  - name: push-broker-production
+    serial_groups: [production]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: broker-src
+            passed: [acceptance-tests-staging]
+            trigger: true
+          - get: pipeline-tasks
+            passed: [push-broker-staging]
+      - put: broker-deploy-production
+        params:
+          path: broker-src
+          manifest: broker-src/manifest.yml
+          environment_variables:
+            UAA_ADDRESS: ((uaa-address-production))
+            UAA_CLIENT_ID: ((uaa-client-id-production))
+            UAA_CLIENT_SECRET: ((uaa-client-secret-production))
+            UAA_ZONE: ((uaa-zone-production))
+            CF_ADDRESS: ((cf-api-url-production))
+            BROKER_USERNAME: ((broker-username-production))
+            BROKER_PASSWORD: ((broker-password-production))
+            EMAIL_ADDRESS: ((email-address-production))
+      - task: update-broker-identity-provider
+        file: pipeline-tasks/register-service-broker.yml
+        params:
+          CF_API_URL: ((cf-api-url-production))
+          CF_USERNAME: ((cf-deploy-username-production))
+          CF_PASSWORD: ((cf-deploy-password-production))
+          CF_ORGANIZATION: ((cf-organization-production))
+          CF_SPACE: ((cf-space-production))
+          BROKER_NAME: uaa-credentials-broker
+          AUTH_USER: ((broker-username-production))
+          AUTH_PASS: ((broker-password-production))
+          SERVICES: cloud-gov-identity-provider
+      - task: update-broker-service-account
+        file: pipeline-tasks/register-service-broker.yml
+        params:
+          CF_API_URL: ((cf-api-url-production))
+          CF_USERNAME: ((cf-deploy-username-production))
+          CF_PASSWORD: ((cf-deploy-password-production))
+          CF_ORGANIZATION: ((cf-organization-production))
+          CF_SPACE: ((cf-space-production))
+          BROKER_NAME: uaa-credentials-broker
+          AUTH_USER: ((broker-username-production))
+          AUTH_PASS: ((broker-password-production))
+          SERVICES: cloud-gov-service-account
+          SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-production))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-failure-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-production))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-success-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
-- name: acceptance-tests-staging
-  serial_groups: [staging]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-staging]
-    trigger: true
-  - task: acceptance-tests-staging
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-staging))
-      CF_USERNAME: ((cf-deploy-username-test-staging))
-      CF_PASSWORD: ((cf-deploy-password-test-staging))
-      CF_ORGANIZATION: ((cf-organization-test-staging))
-      CF_SPACE: ((cf-space-test-staging))
-      UAA_API_URL: ((uaa-address-staging))
-      UAA_CLIENT_ID: ((uaa-client-id-test-staging))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-staging))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
-
-- name: push-broker-production
-  serial_groups: [production]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: broker-src
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: pipeline-tasks
-      passed: [push-broker-staging]
-  - put: broker-deploy-production
-    params:
-      path: broker-src
-      manifest: broker-src/manifest.yml
-      environment_variables:
-        UAA_ADDRESS: ((uaa-address-production))
-        UAA_CLIENT_ID: ((uaa-client-id-production))
-        UAA_CLIENT_SECRET: ((uaa-client-secret-production))
-        UAA_ZONE: ((uaa-zone-production))
-        CF_ADDRESS: ((cf-api-url-production))
-        BROKER_USERNAME: ((broker-username-production))
-        BROKER_PASSWORD: ((broker-password-production))
-        EMAIL_ADDRESS: ((email-address-production))
-  - task: update-broker-identity-provider
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-production))
-      CF_USERNAME: ((cf-deploy-username-production))
-      CF_PASSWORD: ((cf-deploy-password-production))
-      CF_ORGANIZATION: ((cf-organization-production))
-      CF_SPACE: ((cf-space-production))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-production))
-      AUTH_PASS: ((broker-password-production))
-      SERVICES: cloud-gov-identity-provider
-  - task: update-broker-service-account
-    file: pipeline-tasks/register-service-broker.yml
-    params:
-      CF_API_URL: ((cf-api-url-production))
-      CF_USERNAME: ((cf-deploy-username-production))
-      CF_PASSWORD: ((cf-deploy-password-production))
-      CF_ORGANIZATION: ((cf-organization-production))
-      CF_SPACE: ((cf-space-production))
-      BROKER_NAME: uaa-credentials-broker
-      AUTH_USER: ((broker-username-production))
-      AUTH_PASS: ((broker-password-production))
-      SERVICES: cloud-gov-service-account
-      SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy uaa-credentials-broker on ((cf-api-url-production))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-failure-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed uaa-credentials-broker on ((cf-api-url-production))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-success-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-production
-  serial_groups: [production]
-  serial: true
-  plan:
-  - get: broker-src
-    passed: [push-broker-production]
-    trigger: true
-  - task: acceptance-tests-production
-    file: broker-src/acceptance-tests.yml
-    params:
-      CF_API_URL: ((cf-api-url-production))
-      CF_USERNAME: ((cf-deploy-username-test-production))
-      CF_PASSWORD: ((cf-deploy-password-test-production))
-      CF_ORGANIZATION: ((cf-organization-test-production))
-      CF_SPACE: ((cf-space-test-production))
-      UAA_API_URL: ((uaa-address-production))
-      UAA_CLIENT_ID: ((uaa-client-id-test-production))
-      UAA_CLIENT_SECRET: ((uaa-client-secret-test-production))
-      CLIENT_SERVICE_NAME: cloud-gov-identity-provider
-      USER_SERVICE_NAME: cloud-gov-service-account
-      CLIENT_PLAN_NAME: oauth-client
-      USER_PLAN_NAME: space-deployer
-      SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
+  - name: acceptance-tests-production
+    serial_groups: [production]
+    serial: true
+    plan:
+      - get: broker-src
+        passed: [push-broker-production]
+        trigger: true
+      - get: general-task
+      - task: acceptance-tests-production
+        image: general-task
+        file: broker-src/acceptance-tests.yml
+        params:
+          CF_API_URL: ((cf-api-url-production))
+          CF_USERNAME: ((cf-deploy-username-test-production))
+          CF_PASSWORD: ((cf-deploy-password-test-production))
+          CF_ORGANIZATION: ((cf-organization-test-production))
+          CF_SPACE: ((cf-space-test-production))
+          UAA_API_URL: ((uaa-address-production))
+          UAA_CLIENT_ID: ((uaa-client-id-test-production))
+          UAA_CLIENT_SECRET: ((uaa-client-secret-test-production))
+          CLIENT_SERVICE_NAME: cloud-gov-identity-provider
+          USER_SERVICE_NAME: cloud-gov-service-account
+          CLIENT_PLAN_NAME: oauth-client
+          USER_PLAN_NAME: space-deployer
+          SERVICE_INSTANCE_NAME: uaa-credentials-acceptance
 
 resources:
-- name: broker-src
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/uaa-credentials-broker
-    branch: main
+  - name: broker-src
+    type: git
+    source:
+      uri: https://github.com/cloud-gov/uaa-credentials-broker
+      branch: main
 
-- name: pipeline-tasks
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/cg-pipeline-tasks
-    branch: main
-    commit_verification_keys: ((cloud-gov-pgp-keys))
+  - name: pipeline-tasks
+    type: git
+    source:
+      uri: https://github.com/cloud-gov/cg-pipeline-tasks
+      branch: main
+      commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: broker-deploy-staging
-  type: cf
-  source:
-    api: ((cf-api-url-staging))
-    username: ((cf-deploy-username-staging))
-    password: ((cf-deploy-password-staging))
-    organization: ((cf-organization-staging))
-    space: ((cf-space-staging))
+  - name: broker-deploy-staging
+    type: cf
+    source:
+      api: ((cf-api-url-staging))
+      username: ((cf-deploy-username-staging))
+      password: ((cf-deploy-password-staging))
+      organization: ((cf-organization-staging))
+      space: ((cf-space-staging))
 
-- name: broker-deploy-production
-  type: cf
-  source:
-    api: ((cf-api-url-production))
-    username: ((cf-deploy-username-production))
-    password: ((cf-deploy-password-production))
-    organization: ((cf-organization-production))
-    space: ((cf-space-production))
+  - name: broker-deploy-production
+    type: cf
+    source:
+      api: ((cf-api-url-production))
+      username: ((cf-deploy-username-production))
+      password: ((cf-deploy-password-production))
+      organization: ((cf-organization-production))
+      space: ((cf-space-production))
 
-- name: slack
-  type: slack-notification
-  source:
-    url: ((slack-webhook-url))
+  - name: slack
+    type: slack-notification
+    source:
+      url: ((slack-webhook-url))
 
-- name: pull-request
-  type: pull-request
-  check_every: 1m
-  source:
-    repository: cloud-gov/uaa-credentials-broker
-    access_token: ((status-access-token))
-    disable_forks: true
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      repository: cloud-gov/uaa-credentials-broker
+      access_token: ((status-access-token))
+      disable_forks: true
+
+  - name: general-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: general-task
+      aws_region: us-gov-west-1
+      tag: latest
 
 resource_types:
-- name: slack-notification
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: slack-notification-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: slack-notification
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: git
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: git-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: cf
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: cf-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: cf
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: cf-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: registry-image
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: registry-image-resource
-    aws_region: us-gov-west-1
-    tag: latest
-
-- name: pull-request
-  type: docker-image
-  source:
-    repository: teliaoss/github-pr-resource
+  - name: pull-request
+    type: docker-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: github-pr-resource
+      aws_region: us-gov-west-1
+      tag: latest

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -299,7 +299,7 @@ resource_types:
       tag: latest
 
   - name: pull-request
-    type: docker-image
+    type: registry-image
     source:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))

--- a/run-tests.yml
+++ b/run-tests.yml
@@ -1,18 +1,9 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
-- name: pull-request
-  path: uaa-credentials-broker
+  - name: pull-request
+    path: uaa-credentials-broker
 
 run:
   path: uaa-credentials-broker/run-tests.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update pipeline to use hardened general-task image
- Update pipeline to use hardened github-pr-resource image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Update to use hardened images
