### PR TITLE
Fix pipeline for newer register service broker

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -58,7 +58,7 @@ jobs:
             BROKER_PASSWORD: ((broker-password-staging))
             EMAIL_ADDRESS: ((email-address-staging))
       - task: update-broker
-        file: pipeline-tasks/register-service-broker.yml
+        file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
         params:
           CF_API_URL: ((cf-api-url-staging))
           CF_USERNAME: ((cf-deploy-username-staging))
@@ -138,7 +138,7 @@ jobs:
             BROKER_PASSWORD: ((broker-password-production))
             EMAIL_ADDRESS: ((email-address-production))
       - task: update-broker-identity-provider
-        file: pipeline-tasks/register-service-broker.yml
+        file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
         params:
           CF_API_URL: ((cf-api-url-production))
           CF_USERNAME: ((cf-deploy-username-production))
@@ -150,7 +150,7 @@ jobs:
           AUTH_PASS: ((broker-password-production))
           SERVICES: cloud-gov-identity-provider
       - task: update-broker-service-account
-        file: pipeline-tasks/register-service-broker.yml
+        file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
         params:
           CF_API_URL: ((cf-api-url-production))
           CF_USERNAME: ((cf-deploy-username-production))
@@ -161,7 +161,7 @@ jobs:
           AUTH_USER: ((broker-username-production))
           AUTH_PASS: ((broker-password-production))
           SERVICES: cloud-gov-service-account
-          SERVICE_ORGANIZATION_BLACKLIST: ((service-account-blacklist))
+          SERVICE_ORGANIZATION_DENYLIST: ((service-account-blacklist))
     on_failure:
       put: slack
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switch to using the newer style `pipeline-tasks/register-service-broker-and-set-plan-visibility.yml`, Concourse didn't seem to want to follow the symlink introduced with https://github.com/cloud-gov/pipeline-tasks/commit/648a1f7f407b4d0460620cbafed909b2e38bbfe8
- With this also needed to replace the reference to `SERVICE_ORGANIZATION_BLACKLIST` with `SERVICE_ORGANIZATION_DENYLIST` as the older variable has been deprecated
- Part of "make them all green" pipeline maintenance: https://github.com/cloud-gov/private/issues/618

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Returns functionality to what we had before, should not have any changes to our security footprint
