### PR TITLE
Allow unbinding when user is missing

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -214,6 +214,9 @@ func (b *DeployerAccountBroker) Unbind(
 	case userAccountGUID:
 		user, err := b.uaaClient.GetUser(bindingID)
 		if err != nil {
+			if strings.Contains(err.Error(), "got 0") {
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
Customer reported issue deleting service: https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1734453792282829

## Changes proposed in this pull request:
- Replicate the logic present in `Deprovision` logic within the `Unbind` function, allowing the action to proceed if the targeted user no longer exists.

## Security considerations

None